### PR TITLE
[BotMono]假人物品映射：将输入的英文，中文（甚至拼音）指向同一假人并提供操作界面和简化指令的插件

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -82,6 +82,7 @@ If there is any good plugin, please submit a PR, and I will invite you to this o
 | [AutoBot](https://github.com/SCT-Technology/AutoBot) | [MercyNaima](https://github.com/MercyNaima) | A plugin to spawn carpet BOT/BOTS |
 | [MCDR-bot](https://github.com/MCDReforged-Plugins/MCDR-bot) | [Fallen_Breath](https://github.com/Fallen-Breath) | Fake player support based on [pycraft](https://github.com/ammaraskar/pyCraft) |
 | [Bot](https://github.com/zhang-anzhi/MCDReforgedPlugins/tree/master/Bot) | [zhang_anzhi](https://github.com/zhang-anzhi) | Storage bot list, one key to spawn or kill bot |
+| [BotMono](https://github.com/Jerry-FaGe/MCDR-BotMono) | [Jerry-FaGe](https://github.com/Jerry-FaGe) | The input English, Chinese (even Pinyin) points to the same BOT and provides operation interface and simplified instructions |
 
 ### Command Helper
 

--- a/readme_cn.md
+++ b/readme_cn.md
@@ -82,6 +82,7 @@
 | [AutoBot](https://github.com/SCT-Technology/AutoBot) | [MercyNaima](https://github.com/MercyNaima) | 生成，批量生成地毯BOT(BOT组) |
 | [MCDR-bot](https://github.com/MCDReforged-Plugins/MCDR-bot) | [Fallen_Breath](https://github.com/Fallen-Breath) | 使用 [pycraft](https://github.com/ammaraskar/pyCraft) 的假人插件 |
 | [Bot](https://github.com/zhang-anzhi/MCDReforgedPlugins/tree/master/Bot) | [zhang_anzhi](https://github.com/zhang-anzhi) | 存储机器人列表，一键放置/清除机器人 |
+| [BotMono](https://github.com/Jerry-FaGe/MCDR-BotMono) | [Jerry-FaGe](https://github.com/Jerry-FaGe) | 假人物品映射：将输入的英文，中文（甚至拼音）指向同一假人并提供操作界面和简化指令的插件 |
 
 ### 指令助手
 


### PR DESCRIPTION
例如配置文件为{"fireworks": ["fireworks" ,"烟花", "火箭", "烟花火箭"]}，则输入`!!bm 烟花/火箭/烟花火箭/fireworks`都可召唤同一假人，并且在假人未在线的情况下直接输入`!!bm 烟花 all`可以自动召唤假人并扔出假人身上所有物品。`!!bm list`提供一个可点击的操作界面。完整版有传送假人到玩家的功能，和谐版删除此功能，详情见本插件[README.md](https://github.com/Jerry-FaGe/MCDR-BotMono/blob/master/README.md)

```MCDR(虽然知道不可能会支持但还是写上了23333)
本插件中!!bm与!!botmono效果相同，两者可以互相替换
!!bm 显示本帮助信息
!!bm list 显示由本插件召唤出的假人列表
!!bm reload 重载插件配置
!!bm <mono> 召唤一个用于存储<mono>的假人
!!bm <mono> spawn 召唤一个用于存储<mono>的假人
!!bm <mono> kill 干掉用于存储<mono>的假人
!!bm <mono> here 将用于存储<mono>的假人传送到自己身边(为避免争议，会有和谐版本BotMono_safe.py去掉此功能)
!!bm <mono> one 假人扔出一个手中物品（执行此条前无需执行spawn，如假人不存在会自动创建）
!!bm <mono> all 假人扔出身上所有物品（执行此条前无需执行spawn，如假人不存在会自动创建）
!!bm <mono> handall 假人扔出手中所有物品（执行此条前无需执行spawn，如假人不存在会自动创建）
```
* !!bm list
```
当前共有3个假人在线
----------- piston -----------
此假人存放: ['piston', '活塞']
[传送]  [扔出所有]  [扔出一个]  [扔出手中]  [下线]  
----------- sand -----------
此假人存放: ['sand', '沙子']
[传送]  [扔出所有]  [扔出一个]  [扔出手中]  [下线]  
----------- repeater -----------
此假人存放: ['repeater', '红石中继器', '中继器']
[传送]  [扔出所有]  [扔出一个]  [扔出手中]  [下线]
```
