### PR TITLE
[BotKikai]假人器械映射插件

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -84,6 +84,7 @@ If there is any good plugin, please submit a PR, and I will invite you to this o
 | [MCDR-bot](https://github.com/MCDReforged-Plugins/MCDR-bot) | [Fallen_Breath](https://github.com/Fallen-Breath) | Fake player support based on [pycraft](https://github.com/ammaraskar/pyCraft) |
 | [Bot](https://github.com/zhang-anzhi/MCDReforgedPlugins/tree/master/Bot) | [zhang_anzhi](https://github.com/zhang-anzhi) | Storage bot list, one key to spawn or kill bot |
 | [BotMono](https://github.com/Jerry-FaGe/MCDR-BotMono) | [Jerry-FaGe](https://github.com/Jerry-FaGe) | The input English, Chinese (even Pinyin) points to the same BOT and provides operation interface and simplified instructions |
+| [BotKikai](https://github.com/Jerry-FaGe/MCDR-BotKikai) | [Jerry-FaGe](https://github.com/Jerry-FaGe) | Storage bot position list, one key to spawn or kill bot, and can let the bot right click |
 
 ### Command Helper
 

--- a/readme_cn.md
+++ b/readme_cn.md
@@ -84,6 +84,7 @@
 | [MCDR-bot](https://github.com/MCDReforged-Plugins/MCDR-bot) | [Fallen_Breath](https://github.com/Fallen-Breath) | 使用 [pycraft](https://github.com/ammaraskar/pyCraft) 的假人插件 |
 | [Bot](https://github.com/zhang-anzhi/MCDReforgedPlugins/tree/master/Bot) | [zhang_anzhi](https://github.com/zhang-anzhi) | 存储机器人列表，一键放置/清除机器人 |
 | [BotMono](https://github.com/Jerry-FaGe/MCDR-BotMono) | [Jerry-FaGe](https://github.com/Jerry-FaGe) | 假人物品映射：将输入的英文，中文（甚至拼音）指向同一假人并提供操作界面和简化指令的插件 |
+| [BotKikai](https://github.com/Jerry-FaGe/MCDR-BotKikai) | [Jerry-FaGe](https://github.com/Jerry-FaGe) | 假人器械映射：储存假人的位置信息，随时随地一键放置/清除假人，并可以让假人右键|
 
 ### 指令助手
 


### PR DESCRIPTION
正确的添加假人之后可以使用类似`!!bk 刷沙机 use`的指令让假人`sandbot`在刷沙机开关处上线并use一次（`刷沙机`和`sandbot`均可自定义），详见[README.md](https://github.com/Jerry-FaGe/MCDR-BotKikai/blob/master/README.md)
```MCDR
本插件中!!bk与!!botkikai效果相同，两者可以互相替换
!!bk 显示本帮助信息
!!bk list 显示假人列表
!!bk reload 重载插件配置
!!bk add <name> <kikai> 使用当前玩家参数添加一个名为<name>用于<kikai>的假人
!!bk add <name> <kikai> <dim> <pos> <facing> 使用自定义参数添加一个名为<name>用于<kikai>的假人
!!bk del <kikai> 从机器人列表移除用于<kikai>的假人
!!bk <kikai> 输出一个可点击的界面，自动根据假人是否在线改变选项
!!bk <kikai> spawn 召唤一个用于<kikai>的假人
!!bk <kikai> kill 干掉用于<kikai>的假人
!!bk <kikai> use 假人右键一次（执行此条前无需执行spawn，如假人不在线会自动上线）
```

* `!!bk list`
```MCDR
----------- Jerry_FaGe 离线  -----------
此假人用于: ['Jerry_FaGe', '发哥', '开发者', '作者', 'test']
[点击召唤]  [点击use]  [查看详情]
----------- sandbot 在线  -----------
此假人用于: ['sandbot', '刷沙机']
[点击use]  [点击下线]  [查看详情]
----------- stonebot 离线  -----------
此假人用于: ['stonebot', '刷石机']
[点击召唤]  [点击use]  [查看详情]
```

* `!!bk 刷沙机` / `!!bk sandbot`
```MCDR
----------- sandbot 在线 -----------
此假人用于: ['sandbot', '刷沙机']
维度: minecraft:overworld
坐标: [-2.439826988598193, 7.0, -5.05480960268401]
朝向: 180.59103 29.550417
[点击use]  [点击下线]
```